### PR TITLE
Added Pause Menu, functionality limited to resume and quit

### DIFF
--- a/Project/Content/MyContent/BP_MainCharacter.uasset
+++ b/Project/Content/MyContent/BP_MainCharacter.uasset
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:542edec26d2bf0e3a46bf9e8b51b3860bbd33f3de759e1752affadfac216588a
-size 408731
+oid sha256:d7a6efc43a4b29b801e825c41f45529a03e25a928eac72eb6fbc55101aec46ee
+size 442014

--- a/Project/Content/MyContent/BP_PauseMenu.uasset
+++ b/Project/Content/MyContent/BP_PauseMenu.uasset
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:ad52c758aab507d4a6155bf21adc0e3e41dd983572bb3f602b838c3e354770a8
+size 72162


### PR DESCRIPTION
Added Pause Menu that can be accessed by pressing Tab in-game. Only the Resume and Quit button work at this time. The Resume button takes you right back to gameplay, the Quit button returns you to main menu.

I have noticed a glitch. If you start the game, open the pause menu, quit to the main menu, and then hit play on the main menu, when you reenter the game, you can no longer open the pause menu. Not sure how to fix this!